### PR TITLE
Using active_link_to if defined (falling back to link_to)

### DIFF
--- a/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
+++ b/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
@@ -15,10 +15,10 @@ module SigbitAdminRails
 
     def sidebar_item(title, url = nil, &block)
       if block_given?
-        url = "##{(0...20).map { ('a'..'z').to_a[rand(26)] }.join}" unless url.present?
+        url = "##{(0...20).map { ('a'..'z').to_a.sample }.join }" unless url.present?
 
         content_tag :li do
-          concat(link_to("#{title} <i class='fa fa-chevron-right'></i>".html_safe, url, data: {toggle: 'collapse'}))
+          concat(link_to("#{title} #{dropdown_arrow_icon}".html_safe, url, data: { toggle: 'collapse' }))
           concat(content_tag(:ul, class: 'submenu collapse', id: url.delete('#')) do
             yield
           end)
@@ -36,6 +36,10 @@ module SigbitAdminRails
       else
         link_to title, url, options
       end
+    end
+
+    def dropdown_arrow_icon
+      tag :i, class: 'fa fa-chevron-right'
     end
   end
 end

--- a/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
+++ b/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
@@ -15,7 +15,9 @@ module SigbitAdminRails
 
     def sidebar_item(title, url = nil, &block)
       if block_given?
-        url = "##{(0...20).map { ('a'..'z').to_a.sample }.join }" unless url.present?
+        url = "##{(0...20).map {
+          ('a'..'z').to_a.sample
+        }.join }" unless url.present?
 
         content_tag :li do
           concat(link_to("#{title} #{dropdown_arrow_icon}".html_safe, url, data: { toggle: 'collapse' }))

--- a/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
+++ b/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
@@ -15,9 +15,7 @@ module SigbitAdminRails
 
     def sidebar_item(title, url = nil, &block)
       if block_given?
-        url = "##{(0...20).map {
-          ('a'..'z').to_a.sample
-        }.join }" unless url.present?
+        url = "##{generate_random_id}" unless url.present?
 
         content_tag :li do
           concat(link_to("#{title} #{dropdown_arrow_icon}".html_safe, url, data: { toggle: 'collapse' }))
@@ -42,6 +40,10 @@ module SigbitAdminRails
 
     def dropdown_arrow_icon
       tag :i, class: 'fa fa-chevron-right'
+    end
+
+    def generate_random_id
+      (0...20).map { ('a'..'z').to_a.sample }.join
     end
   end
 end

--- a/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
+++ b/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
@@ -17,7 +17,9 @@ module SigbitAdminRails
       if block_given?
         url = "##{generate_random_id}" unless url.present?
         content_tag :li do
-          concat(link_to("#{ title } #{ dropdown_arrow_icon }".html_safe, url, data: { toggle: 'collapse' }))
+          concat(
+              link_to("#{ title } #{ dropdown_arrow_icon }".html_safe, url, data: {toggle: 'collapse'})
+          )
           concat(content_tag(:ul, class: 'submenu collapse', id: url.delete('#')) do
             yield
           end)

--- a/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
+++ b/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
@@ -23,7 +23,7 @@ module SigbitAdminRails
           )
           concat(
             content_tag(:ul, class: 'submenu collapse',
-                        id: url.delete('#')) do
+                                id: url.delete('#')) do
               yield
             end
           )

--- a/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
+++ b/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
@@ -17,7 +17,7 @@ module SigbitAdminRails
       if block_given?
         url = "##{generate_random_id}" unless url.present?
         content_tag :li do
-          concat(link_to("#{title} #{dropdown_arrow_icon}".html_safe, url, data: {toggle: 'collapse'}))
+          concat(link_to("#{ title } #{ dropdown_arrow_icon }".html_safe, url, data: { toggle: 'collapse' }))
           concat(content_tag(:ul, class: 'submenu collapse', id: url.delete('#')) do
             yield
           end)

--- a/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
+++ b/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
@@ -18,7 +18,8 @@ module SigbitAdminRails
         url = "##{generate_random_id}" unless url.present?
         content_tag :li do
           concat(
-            link_to("#{ title } #{ arrow_icon }".html_safe, url, data: {toggle: 'collapse'})
+            link_to("#{ title } #{ arrow_icon }".html_safe,
+                    url, data: { toggle: 'collapse' })
           )
           concat(content_tag(:ul, class: 'submenu collapse', id: url.delete('#')) do
             yield

--- a/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
+++ b/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
@@ -16,25 +16,24 @@ module SigbitAdminRails
     def sidebar_item(title, url = nil, &block)
       if block_given?
         url = "##{generate_random_id}" unless url.present?
-
         content_tag :li do
-          concat(link_to("#{title} #{dropdown_arrow_icon}".html_safe, url, data: { toggle: 'collapse' }))
+          concat(link_to("#{title} #{dropdown_arrow_icon}".html_safe, url, data: {toggle: 'collapse'}))
           concat(content_tag(:ul, class: 'submenu collapse', id: url.delete('#')) do
             yield
           end)
         end
       else
-        content_tag :li, class: 'nav-item' do
-          smart_link_to title, url, class: 'nav-link'
-        end
+        smart_link_to title, url, class: 'nav-link'
       end
     end
 
     def smart_link_to(title, url, options = {})
-      if defined?(ActiveLinkTo)
-        active_link_to(title, url, options)
-      else
-        link_to title, url, options
+      content_tag :li, class: 'nav-item' do
+        if defined?(ActiveLinkTo)
+          active_link_to(title, url, options)
+        else
+          link_to title, url, options
+        end
       end
     end
 

--- a/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
+++ b/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
@@ -18,7 +18,7 @@ module SigbitAdminRails
         url = "##{generate_random_id}" unless url.present?
         content_tag :li do
           concat(
-              link_to("#{ title } #{ dropdown_arrow_icon }".html_safe, url, data: {toggle: 'collapse'})
+            link_to("#{ title } #{ dropdown_arrow_icon }".html_safe, url, data: {toggle: 'collapse'})
           )
           concat(content_tag(:ul, class: 'submenu collapse', id: url.delete('#')) do
             yield

--- a/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
+++ b/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
@@ -4,11 +4,10 @@ module SigbitAdminRails
       options = args.extract_options!
       if block_given?
         content_tag :div, id: 'sidebar-wrapper' do
-          html = link_to '', options[:brand_url], class: 'sidebar-brand hidden-sm-down'
-          html << content_tag(:ul, class: 'sidebar-nav') do
+          concat(link_to '', options[:brand_url], class: 'sidebar-brand hidden-sm-down')
+          concat(content_tag(:ul, class: 'sidebar-nav') do
             yield
-          end
-          html.html_safe
+          end)
         end
       end
     end
@@ -17,16 +16,10 @@ module SigbitAdminRails
       if block_given?
         url = "##{generate_random_id}" unless url.present?
         content_tag :li do
-          concat(
-            link_to("#{ title } #{ arrow_icon }".html_safe,
-                    url, data: { toggle: 'collapse' })
-          )
-          concat(
-            content_tag(:ul, class: 'submenu collapse',
-                                id: url.delete('#')) do
-              yield
-            end
-          )
+          concat(link_to("#{ title } #{ arrow_icon }".html_safe, url, data: { toggle: 'collapse' }))
+          concat(content_tag(:ul, class: 'submenu collapse', id: url.delete('#')) do
+            yield
+          end)
         end
       else
         smart_link_to title, url, class: 'nav-link'

--- a/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
+++ b/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
@@ -13,17 +13,29 @@ module SigbitAdminRails
       end
     end
 
-    def sidebar_item(title, url, &block)
+    def sidebar_item(title, url = nil, &block)
       if block_given?
+        url = "##{(0...20).map { ('a'..'z').to_a[rand(26)] }.join}" unless url.present?
+
         content_tag :li do
-          html = link_to("#{title} <i class='fa fa-chevron-right'></i>".html_safe, url, data: { toggle: 'collapse' })
-          html << content_tag(:ul, class: 'submenu collapse', id: url.delete('#')) do
+          concat(link_to("#{title} <i class='fa fa-chevron-right'></i>".html_safe, url, data: {toggle: 'collapse'}))
+          concat(content_tag(:ul, class: 'submenu collapse', id: url.delete('#')) do
             yield
-          end
-          html.html_safe
+          end)
         end
       else
-        "<li>#{link_to title, url}</li>".html_safe
+        content_tag :li, class: 'nav-item' do
+          smart_link_to title, url, class: 'nav-link'
+        end
       end
-    end  end
+    end
+
+    def smart_link_to(title, url, options = {})
+      if defined?(ActiveLinkTo)
+        active_link_to(title, url, options)
+      else
+        link_to title, url, options
+      end
+    end
+  end
 end

--- a/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
+++ b/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
@@ -21,9 +21,12 @@ module SigbitAdminRails
             link_to("#{ title } #{ arrow_icon }".html_safe,
                     url, data: { toggle: 'collapse' })
           )
-          concat(content_tag(:ul, class: 'submenu collapse', id: url.delete('#')) do
-            yield
-          end)
+          concat(
+            content_tag(:ul, class: 'submenu collapse',
+                        id: url.delete('#')) do
+              yield
+            end
+          )
         end
       else
         smart_link_to title, url, class: 'nav-link'

--- a/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
+++ b/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
@@ -44,7 +44,8 @@ module SigbitAdminRails
     end
 
     def arrow_icon
-      tag :i, class: 'fa fa-chevron-right'
+      content_tag :i, class: 'fa fa-chevron-right' do
+      end
     end
 
     def generate_random_id

--- a/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
+++ b/lib/sigbit_admin_rails/helpers/sidebar_helper.rb
@@ -18,7 +18,7 @@ module SigbitAdminRails
         url = "##{generate_random_id}" unless url.present?
         content_tag :li do
           concat(
-            link_to("#{ title } #{ dropdown_arrow_icon }".html_safe, url, data: {toggle: 'collapse'})
+            link_to("#{ title } #{ arrow_icon }".html_safe, url, data: {toggle: 'collapse'})
           )
           concat(content_tag(:ul, class: 'submenu collapse', id: url.delete('#')) do
             yield
@@ -39,7 +39,7 @@ module SigbitAdminRails
       end
     end
 
-    def dropdown_arrow_icon
+    def arrow_icon
       tag :i, class: 'fa fa-chevron-right'
     end
 


### PR DESCRIPTION
- Cleaning up concat of html (no longer need html_safe on generated output)
- Removing inline html (except the icon chevron)
- When a block is passed to sidebar_item (for generating a dropdown), an random id is created

closes #10 